### PR TITLE
Grammar Index: Corrected Lesson 8 Typos

### DIFF
--- a/lessons/appendix/grammar-index/index.html
+++ b/lessons/appendix/grammar-index/index.html
@@ -5657,7 +5657,7 @@
               <td>
                 <ol>
                   <li>経済<b class="main-color">は</b><ruby>政治<rt>せいじ</rt></ruby><small>(politics)</small><b class="main-color">と</b>深い<b class="main-color">関係がある</b>。</li>
-                  <li>そのトピック<b class="main-color">に関係のある</b>本はその例にありますよ。</li>
+                  <li>そのトピック<b class="main-color">に関係のある</b>本はこの列にありますよ。</li>
                   <li>授業<b class="main-color">に関係のない</b>質問はしないようにしましょう。</li>
                   <li>それ<b class="main-color">は</b>、僕<b class="main-color">には関係がない</b>から、知らないなあ。</li>
                 </ol>
@@ -5704,7 +5704,7 @@
                   <li>地球<ruby>温暖化<rt>おんだんか</rt></ruby><small>(global warming)</small><b class="main-color">によって</b><ruby>北極<rt>ほっきょく</rt></ruby><small>(the North Pole)</small>の<ruby>氷<rt>こおり</rt></ruby><small>(ice)</small>が<ruby>溶<rt>と</rt></ruby>けて<small>(to melt)</small>いるらしい。[cause]</li>
                   <li>インターネットで調べる<b class="main-color">ことによって</b>、世界中で今<ruby>起<rt>お</rt></ruby>こっていることを知ることが出来る。[means]</li>
                   <li>言葉は、話したり読んだり書いたりする<b class="main-color">ことによって</b>学んでいくのです。[means]</li>
-                  <li><ruby>万有引力<rt>ばんゆういんりょく</rt></ruby><small>(the law of universal gravitation)</small>ニュートン<b class="main-color">によって</b><ruby>発見<rt>はっけん</rt></ruby>されました<small>(to be discovered)</small>。[agent]</li>
+                  <li><ruby>万有引力<rt>ばんゆういんりょく</rt></ruby><small>(the law of universal gravitation)</small>はニュートン<b class="main-color">によって</b><ruby>発見<rt>はっけん</rt></ruby>されました<small>(to be discovered)</small>。[agent]</li>
                 </ol>
               </td>
             </tr>
@@ -5775,7 +5775,7 @@
             </tr>
             <tr>
               <td>説明</td>
-              <td>When 通り is modified by a verb or a noun, it means "the way; as someone does; as something indicates." 通り can aslo be used as a suffix, in which case 通り is directly affixed to nouns and the pronunciation changes to どおり.</td>
+              <td>When 通り is modified by a verb or a noun, it means "the way; as someone does; as something indicates." 通り can also be used as a suffix, in which case 通り is directly affixed to nouns and the pronunciation changes to どおり.</td>
             </tr>
             <tr>
               <td>英訳</td>
@@ -5794,7 +5794,7 @@
               <td>
                 <ol>
                   <li>母が教えてくれた<b class="main-color">通り</b>作ったら、おいしいケーキができた。</li>
-                  <li><ruby>空手<rt>からて</rt></ruby>部では、先輩に言われた<b class="main-color">通りに</b>しないと、怒られてします。</li>
+                  <li><ruby>空手<rt>からて</rt></ruby>部では、先輩に言われた<b class="main-color">通りに</b>しないと、怒られてしまう。</li>
                   <li>日本のファミリーレストランの<ruby>店員<rt>てんいん</rt></ruby>は、みんなマニュアルの<b class="main-color">通りに</b>話すから、ロボットみたいだ。</li>
                   <li><ruby>指示<rt>しじ</rt></ruby><small>(instruction)</small><b class="main-color"><ruby>通<rt>どお</rt></ruby>りに</b>、ここに答えを書いて下さい。</li>
                 </ol>
@@ -6078,7 +6078,7 @@
                 <ol>
                   <li>この<b class="main-color">点</b>について、もう一度、説明していただけませんか。</li>
                   <li>この留学プログラムは、ホームステイが出来るという<b class="main-color">点</b>が、セールスポイントですね。</li>
-                  <li>店に行かなくても買い物が出来るという<b class="main-color">点</b>が、ネットショッピングに人気がる<b class="main-color">点</b>です。</li>
+                  <li>店に行かなくても買い物が出来るという<b class="main-color">点</b>が、ネットショッピングに人気がある<b class="main-color">点</b>です。</li>
                   <li>サービスという<b class="main-color">点</b>では、日本のデパートは最高だ。</li>
                   <li>この車はガソリンがなくても走れるという<b class="main-color">点</b>で<ruby>環境<rt>かんきょう</rt></ruby><small>(environment)</small>にいいですが、値段が高いです。</li>
                 </ol>


### PR DESCRIPTION
Hello! I spotted some typos in the Grammar Index when studying Lesson 8:
___
#l8-p1

例文 2: その例に > **この列**に

___
#l8-p2

例文 5: gravitation)</small>ニュートン > gravitation)</small>**は**ニュートン

___
#l8-p4

説明:  can aslo be used > can **also** be used

例文 2: 怒られてします > 怒られてしま**う**

___
#l8-p10

例文 3: 人気がる > 人気が**あ**る