### PR TITLE
Grammar Index: fix L9-L11 typos

### DIFF
--- a/lessons/appendix/grammar-index/index.html
+++ b/lessons/appendix/grammar-index/index.html
@@ -7047,7 +7047,7 @@
               <td>
                 <ol>
                   <li>私の知っている<b class="main-color">限り</b>、外国人が使いやすい日本語の辞書はないんですよ。</li>
-                  <li>明日までにこのレポートを<ruby>翻訳<rt>ほにゃく</rt></ruby>するのは結構大変ですが、できる<b class="main-color">限り</b><ruby>頑張<rt>がんば</rt></ruby>ってみます。</li>
+                  <li>明日までにこのレポートを<ruby>翻訳<rt>ほんやく</rt></ruby>するのは結構大変ですが、できる<b class="main-color">限り</b><ruby>頑張<rt>がんば</rt></ruby>ってみます。</li>
                   <li>プレイスメントテストに合格しない<b class="main-color">限り</b>、上のレベルのクラスには入れません。</li>
                   <li>この大学の学生である<b class="main-color">限り</b>、大学が決めたルールは守らなくてはいけません。</li>
                 </ol>
@@ -7420,7 +7420,7 @@
               <td>
                 <ol>
                   <li>冬の間、カエル<small>(frog)</small>は、<b class="main-color">まるで</b>死んだ<b class="main-color">ように</b>動きません。</li>
-                  <li>まだ春なのに、今日は<b class="main-color">まるで</b>夏の<b class="main-color">ように</b>暑い</li>
+                  <li>まだ春なのに、今日は<b class="main-color">まるで</b>夏の<b class="main-color">ように</b>暑い。</li>
                   <li>このロボットは、<b class="main-color">まるで</b>人間の<b class="main-color">ように</b>歩くことが出来ます。</li>
                 </ol>
               </td>
@@ -7765,7 +7765,7 @@
                   <li>悲しい<b class="main-color">ことに</b>、大学を卒業してから、大学時代の友達と会えなくなってしまった。</li>
                   <li>残念な<b class="main-color">ことに</b>、私達のチームは最後の試合で負けてしまった。</li>
                   <li>幸せな<b class="main-color">ことに</b>、年を取っても、体だけは健康です。</li>
-                  <li>驚いた<b class="main-color">ことに</b>、この島は人間の言葉が話せるらしい。</li>
+                  <li>驚いた<b class="main-color">ことに</b>、この鳥は人間の言葉が話せるらしい。</li>
                 </ol>
               </td>
             </tr>
@@ -7819,7 +7819,7 @@
             </tr>
             <tr>
               <td>説明</td>
-              <td>The compound particle に対して is used to mark something to/toward/about which one does something, or mark someone to/toward whom one does something or owes something. In different contexts, に対して is used to mark something one has an interest in. に対する is a noun-modifiction form. (The に対して introduced here should not be confused with に対して in <a href="#l9-p13">L9 文法ノート13</a>, which is used to contrast two actions, states, situations, etc.)</td>
+              <td>The compound particle に対して is used to mark something to/toward/about which one does something, or mark someone to/toward whom one does something or owes something. In different contexts, に対して is used to mark something one has an interest in. に対する is a noun-modification form. (The に対して introduced here should not be confused with に対して in <a href="#l9-p13">L9 文法ノート13</a>, which is used to contrast two actions, states, situations, etc.)</td>
             </tr>
             <tr>
               <td>英訳</td>
@@ -8200,7 +8200,7 @@
               <td>
                 <ol>
                   <li>ここには<b class="main-color">各</b>先生のメールアドレスと、<b class="main-color">各</b>セクションの教室の番号が書いてあります。</li>
-                  <li><b class="main-color">各</b>学年から選べれ多学生が、スピーチコンテストに出ることになった。</li>
+                  <li><b class="main-color">各</b>学年から選ばれた多学生が、スピーチコンテストに出ることになった。</li>
                   <li>アメリカでは、お酒が飲める<ruby>年齢<rt>ねんれい</rt></ruby><small>(age)</small>についての規制は、<b class="main-color">各</b>州でそれぞれ違う。</li>
                   <li><ruby><b class="main-color">各</b>国<rt>かっこく</rt></ruby>の代表者が集まって、テロの犯罪について会議を聞いた。</li>
                 </ol>
@@ -8620,7 +8620,7 @@
                 <ol>
                   <li>日本の<ruby>国土<rt>こくど</rt></ruby><small>(national land)</small>は<ruby>狭<rt>せま</rt></ruby>そうに思われているが、数学<b class="main-color">の上で</b>見ると、そうでもない。</li>
                   <li><ruby>翻訳<rt>ほんやく</rt></ruby><b class="main-color">の上で</b>の間違いが、お互いの国の間に<ruby>誤解<rt>ごかい</rt></ruby><small>(misunderstanding)</small>を生んでしまった。</li>
-                  <li>この<ruby>公園<rt>こうえん</rt></ruby>は地区<b class="main-color">の上で</b>は家から近いように見えるが、歩くと結構時間がかかる。</li>
+                  <li>この<ruby>公園<rt>こうえん</rt></ruby>は地図<b class="main-color">の上で</b>は家から近いように見えるが、歩くと結構時間がかかる。</li>
                   <li>田中さんは、健康<b class="main-color">上</b>の問題があって、仕事を<ruby>辞<rt>や</rt></ruby>めた。</li>
                   <li>日本の歴史<b class="main-color">上</b>、<ruby>明治維新<rt>めいじいしん</rt></ruby><small>(the Meiji Restoration)</small>は大きい意味を持っている。</li>
                 </ol>
@@ -8664,7 +8664,7 @@
               <td>
                 <ol>
                   <li>アラビア語は、日本語やロシア語<b class="main-color">と並んで</b>難しい言葉だと言われている。</li>
-                  <li>この大学のビジネス学部は、医者部<b class="main-color">と並んで</b>入るのが難しいらしい。</li>
+                  <li>この大学のビジネス学部は、医学部<b class="main-color">と並んで</b>入るのが難しいらしい。</li>
                   <li><ruby>奈良<rt>なら</rt></ruby>は京都<b class="main-color">と並んで</b>、古い歴史のある町で、日本の<ruby>首都<rt>しゅと</rt></ruby>だったこともある。</li>
                 </ol>
               </td>
@@ -8741,7 +8741,7 @@
             <tr>
               <td>文型</td>
               <td>
-                a. まったく{V/A/ANa/ANo/(の)N}：まったく{<ruby>腹<rt>はら</rt></ruby>が<ruby>立<rt>た</rt></ruby>つ<small>(to be angry)</small>／<ruby>感心<rt>かんしん</rt></ruby>する<small>(to be impressed)</small>／驚いた／あきらめた}; まったく{すごい／えらい／すばらしい}; まったく{だめだ／不思議だ}; まったく(の)うそだ; まったく(の)間違いだ; まったく(の)<ruby>誤解<rt>ごかい</rt></ruby><small>(miunderstanding)</small>だ<br>
+                a. まったく{V/A/ANa/ANo/(の)N}：まったく{<ruby>腹<rt>はら</rt></ruby>が<ruby>立<rt>た</rt></ruby>つ<small>(to be angry)</small>／<ruby>感心<rt>かんしん</rt></ruby>する<small>(to be impressed)</small>／驚いた／あきらめた}; まったく{すごい／えらい／すばらしい}; まったく{だめだ／不思議だ}; まったく(の)うそだ; まったく(の)間違いだ; まったく(の)<ruby>誤解<rt>ごかい</rt></ruby><small>(misunderstanding)</small>だ<br>
                 b. まったく～ない：まったく{出来ない／分からない／読めない}; まったく面白くない<br>
                 c. まったく～(という)わけではない：まったくあきらめた(という)わけではない; まったく安い(という)わけではない; まったくだめ{な／だという}わけではない; まったく(の)うそ(だ)(という)わけではない
               </td>


### PR DESCRIPTION
Hi! Spotted a few more typos. Four more chapters left to study, almost done. Thanks for this amazing resource!
___
#l9-p14

例文2: ほにゃく > ほ**んや**く
___
#l10-p4

例文2: added 。at end of sentence
___
#l10-p12

例文5: この島は > この**鳥**は
___
#l10-p14

説明: noun-modifiction > noun-modific**a**tion
___
#l11-p5

例文2:  選べれ学生 > 選**ばれた**学生
___
#l11-p15

例文3:  は地区 > は地**図**
___
#l11-p16

例文2: 医者部 > 医**学**部
___
#l11-p18

文型: (miunderstanding) > mi**s**understanding
